### PR TITLE
Cordova plugins are getting renamed and this follows the new convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 
 ```bash
 $ git clone https://github.com/romk1n/MyCordovaShop.git
-$ cordova plugin add org.apache.cordova.console
+$ cordova plugin add cordova-plugin-console
 $ cordova plugin add com.paypal.cordova.mobilesdk
 $ cordova platform add ios
 $ cordova platform add android   


### PR DESCRIPTION
To remove this warning:

WARNING: org.apache.cordova.console has been renamed to cordova-plugin-console. You may not be getting the latest version! We suggest you `cordova plugin rm org.apache.cordova.console` and `cordova plugin add cordova-plugin-console`.
